### PR TITLE
Add CSV-driven lecture request generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,26 @@ In this exercise, you will:
 ---
 
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
+
+## 講義依頼文の生成
+
+CSVファイルから講義依頼文を生成するスクリプトを追加しました。CSVの1行が1件の依頼文になります。
+
+### 生成対象のCSVカラム
+
+| カラム名 | 必須/任意 | 説明 |
+| --- | --- | --- |
+| 講師 | 必須 | 宛名となる講師名 |
+| 講師所属 | 必須 | 講師の所属 |
+| 研修名 | 必須 | 研修の名称 |
+| 講義日時 | 必須 | 講義の日時 |
+| 講義課目 | 必須 | 講義の課目 |
+| 備考 | 任意 | 追加の補足事項 |
+
+### 使い方
+
+```bash
+python3 generate_requests.py --csv /path/to/requests.csv
+```
+
+出力は標準出力に表示され、複数行ある場合は `---` 区切りで並びます。

--- a/generate_requests.py
+++ b/generate_requests.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Generate lecture request letters from a CSV file."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+REQUIRED_COLUMNS = ["講師", "講師所属", "研修名", "講義日時", "講義課目"]
+OPTIONAL_COLUMNS = ["備考"]
+
+TEMPLATE = """{講師} 様
+
+{講師所属} の皆様には平素より大変お世話になっております。
+下記研修にてご講義を賜りたく、お願い申し上げます。
+
+■ 研修名: {研修名}
+■ 講義日時: {講義日時}
+■ 講義課目: {講義課目}
+{備考行}
+ご多用のところ恐れ入りますが、ご検討のほどよろしくお願いいたします。
+"""
+
+
+def build_request(row: dict[str, str]) -> str:
+    """Build a request letter for a single CSV row."""
+
+    missing = [col for col in REQUIRED_COLUMNS if not row.get(col, "").strip()]
+    if missing:
+        missing_list = ", ".join(missing)
+        raise ValueError(f"必須カラムが未入力です: {missing_list}")
+
+    note = row.get("備考", "").strip()
+    note_line = f"■ 備考: {note}" if note else ""
+
+    return TEMPLATE.format(
+        **row,
+        備考行=note_line,
+    ).strip()
+
+
+def read_csv_rows(csv_path: Path) -> list[dict[str, str]]:
+    with csv_path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise ValueError("CSVにヘッダー行がありません。")
+
+        missing_columns = [
+            col for col in REQUIRED_COLUMNS if col not in reader.fieldnames
+        ]
+        if missing_columns:
+            missing_list = ", ".join(missing_columns)
+            raise ValueError(f"必須カラムが不足しています: {missing_list}")
+
+        rows = []
+        for row in reader:
+            rows.append({key: (value or "").strip() for key, value in row.items()})
+        return rows
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="CSVファイルから講義依頼文を生成します。",
+    )
+    parser.add_argument(
+        "--csv",
+        dest="csv_path",
+        type=Path,
+        required=True,
+        help="読み込み対象のCSVファイルパス",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        rows = read_csv_rows(args.csv_path)
+    except (OSError, ValueError) as exc:
+        print(f"エラー: {exc}", file=sys.stderr)
+        return 1
+
+    if not rows:
+        print("エラー: CSVにデータ行がありません。", file=sys.stderr)
+        return 1
+
+    letters = []
+    for index, row in enumerate(rows, start=1):
+        try:
+            letters.append(build_request(row))
+        except ValueError as exc:
+            print(f"エラー: {index}行目: {exc}", file=sys.stderr)
+            return 1
+
+    print("\n\n---\n\n".join(letters))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Provide a simple tool to generate formal lecture request letters from tabular data so one CSV row maps to one request.
- Define and enforce the required CSV schema for predictable generation and to reduce manual editing.

### Description

- Add `generate_requests.py`, a Python script that reads a CSV (with `utf-8-sig`), validates required headers, and converts each row into a templated request letter.
- Implement `REQUIRED_COLUMNS` and `OPTIONAL_COLUMNS`, a `TEMPLATE`, `read_csv_rows()` to parse and validate the CSV, `build_request()` to fill the template, and a `main()` CLI that accepts `--csv` and prints letters separated by `---`.
- The script returns non-zero and prints clear `エラー:` messages when required headers are missing, required values are empty, the CSV has no header, or there are no data rows.
- Update `README.md` to document the expected CSV columns and show usage with `python3 generate_requests.py --csv /path/to/requests.csv`.

### Testing

- No automated tests were run as part of this change.
- Basic validation logic exists in the script to detect missing headers and empty required fields and will exit with status `1` on error when executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988163cf6f88326bb8b6bd3add05496)