### PR TITLE
Add a simple browser-based poker game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>シンプルポーカー</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>🃏 シンプルポーカー</h1>
+      <p class="description">「ゲーム開始」であなたとディーラーに5枚ずつ配られ、役の強さで勝敗が決まります。</p>
+
+      <section>
+        <h2>あなたの手札</h2>
+        <div id="player-cards" class="cards"></div>
+        <p id="player-hand" class="hand-text">-</p>
+      </section>
+
+      <section>
+        <h2>ディーラーの手札</h2>
+        <div id="dealer-cards" class="cards"></div>
+        <p id="dealer-hand" class="hand-text">-</p>
+      </section>
+
+      <button id="deal-button">ゲーム開始</button>
+      <p id="result" class="result">ボタンを押して開始してください。</p>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,145 @@
+const suits = ["♠", "♥", "♦", "♣"];
+const ranks = [2, 3, 4, 5, 6, 7, 8, 9, 10, "J", "Q", "K", "A"];
+
+const handLabels = [
+  "ハイカード",
+  "ワンペア",
+  "ツーペア",
+  "スリーカード",
+  "ストレート",
+  "フラッシュ",
+  "フルハウス",
+  "フォーカード",
+  "ストレートフラッシュ",
+  "ロイヤルフラッシュ",
+];
+
+const playerCardsEl = document.getElementById("player-cards");
+const dealerCardsEl = document.getElementById("dealer-cards");
+const playerHandEl = document.getElementById("player-hand");
+const dealerHandEl = document.getElementById("dealer-hand");
+const resultEl = document.getElementById("result");
+const dealButton = document.getElementById("deal-button");
+
+dealButton.addEventListener("click", () => {
+  const deck = createDeck();
+  shuffle(deck);
+
+  const player = deck.splice(0, 5);
+  const dealer = deck.splice(0, 5);
+
+  renderCards(playerCardsEl, player);
+  renderCards(dealerCardsEl, dealer);
+
+  const playerScore = evaluateHand(player);
+  const dealerScore = evaluateHand(dealer);
+
+  playerHandEl.textContent = `役: ${handLabels[playerScore.rank]}`;
+  dealerHandEl.textContent = `役: ${handLabels[dealerScore.rank]}`;
+
+  const outcome = compareScores(playerScore, dealerScore);
+  resultEl.textContent = outcome > 0 ? "あなたの勝ち！" : outcome < 0 ? "ディーラーの勝ち！" : "引き分け！";
+});
+
+function createDeck() {
+  const deck = [];
+  for (const suit of suits) {
+    for (const rank of ranks) {
+      deck.push({ suit, rank });
+    }
+  }
+  return deck;
+}
+
+function shuffle(deck) {
+  for (let i = deck.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [deck[i], deck[j]] = [deck[j], deck[i]];
+  }
+}
+
+function renderCards(container, cards) {
+  container.innerHTML = "";
+  cards.forEach((card) => {
+    const el = document.createElement("div");
+    const isRed = card.suit === "♥" || card.suit === "♦";
+    el.className = `card ${isRed ? "red" : ""}`.trim();
+    el.textContent = `${card.rank}${card.suit}`;
+    container.appendChild(el);
+  });
+}
+
+function cardValue(rank) {
+  if (rank === "A") return 14;
+  if (rank === "K") return 13;
+  if (rank === "Q") return 12;
+  if (rank === "J") return 11;
+  return rank;
+}
+
+function evaluateHand(hand) {
+  const values = hand.map((c) => cardValue(c.rank)).sort((a, b) => b - a);
+  const suitsInHand = hand.map((c) => c.suit);
+
+  const counts = new Map();
+  for (const v of values) counts.set(v, (counts.get(v) || 0) + 1);
+
+  const grouped = [...counts.entries()].sort((a, b) => {
+    if (b[1] !== a[1]) return b[1] - a[1];
+    return b[0] - a[0];
+  });
+
+  const isFlush = suitsInHand.every((s) => s === suitsInHand[0]);
+  const uniqueAsc = [...new Set(values)].sort((a, b) => a - b);
+  let straightHigh = null;
+
+  if (uniqueAsc.length === 5) {
+    if (uniqueAsc[4] - uniqueAsc[0] === 4) straightHigh = uniqueAsc[4];
+    else if (JSON.stringify(uniqueAsc) === JSON.stringify([2, 3, 4, 5, 14])) straightHigh = 5;
+  }
+
+  if (isFlush && straightHigh === 14) return { rank: 9, tiebreakers: [14] };
+  if (isFlush && straightHigh) return { rank: 8, tiebreakers: [straightHigh] };
+
+  if (grouped[0][1] === 4) {
+    const kicker = grouped[1][0];
+    return { rank: 7, tiebreakers: [grouped[0][0], kicker] };
+  }
+
+  if (grouped[0][1] === 3 && grouped[1][1] === 2) {
+    return { rank: 6, tiebreakers: [grouped[0][0], grouped[1][0]] };
+  }
+
+  if (isFlush) return { rank: 5, tiebreakers: values };
+  if (straightHigh) return { rank: 4, tiebreakers: [straightHigh] };
+
+  if (grouped[0][1] === 3) {
+    const kickers = grouped.slice(1).map(([v]) => v).sort((a, b) => b - a);
+    return { rank: 3, tiebreakers: [grouped[0][0], ...kickers] };
+  }
+
+  if (grouped[0][1] === 2 && grouped[1][1] === 2) {
+    const pairs = [grouped[0][0], grouped[1][0]].sort((a, b) => b - a);
+    const kicker = grouped[2][0];
+    return { rank: 2, tiebreakers: [...pairs, kicker] };
+  }
+
+  if (grouped[0][1] === 2) {
+    const kickers = grouped.slice(1).map(([v]) => v).sort((a, b) => b - a);
+    return { rank: 1, tiebreakers: [grouped[0][0], ...kickers] };
+  }
+
+  return { rank: 0, tiebreakers: values };
+}
+
+function compareScores(a, b) {
+  if (a.rank !== b.rank) return a.rank > b.rank ? 1 : -1;
+
+  const maxLen = Math.max(a.tiebreakers.length, b.tiebreakers.length);
+  for (let i = 0; i < maxLen; i++) {
+    const av = a.tiebreakers[i] || 0;
+    const bv = b.tiebreakers[i] || 0;
+    if (av !== bv) return av > bv ? 1 : -1;
+  }
+  return 0;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,83 @@
+:root {
+  color-scheme: light;
+  font-family: "Segoe UI", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at top, #1f8f56, #0f4f2f);
+  color: #fff;
+}
+
+.container {
+  width: min(680px, 92vw);
+  background: rgba(0, 0, 0, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  padding: 1.25rem;
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.25);
+}
+
+h1,
+h2 {
+  margin: 0.4rem 0;
+}
+
+.description {
+  opacity: 0.9;
+}
+
+.cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  margin: 0.5rem 0;
+}
+
+.card {
+  width: 56px;
+  height: 78px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  background: #fdfdfd;
+  color: #1b1b1b;
+  font-weight: 700;
+  font-size: 1.05rem;
+  border: 1px solid #ddd;
+}
+
+.card.red {
+  color: #bb1824;
+}
+
+.hand-text {
+  margin-top: 0;
+  opacity: 0.95;
+}
+
+button {
+  margin-top: 0.8rem;
+  width: 100%;
+  padding: 0.8rem;
+  border: none;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  background: #ffd54f;
+  color: #2b1b00;
+}
+
+button:hover {
+  filter: brightness(1.06);
+}
+
+.result {
+  margin-bottom: 0;
+  font-size: 1.1rem;
+  font-weight: 700;
+}


### PR DESCRIPTION
## Summary
- add a lightweight browser poker game UI in `index.html`
- style the game layout and playing cards in `styles.css`
- implement deck creation, shuffling, hand evaluation, and winner comparison in `script.js`

## Details
- deals 5 cards each to player and dealer
- evaluates standard poker hands from high card through royal flush
- resolves ties with hand-specific tiebreakers
- displays each side’s hand name and the final game result

## Validation
- launched a local static server and loaded the app in a browser automation session
- clicked the game start button and captured a screenshot of the rendered game state

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d5185cae88326adb9e00a4ea8f8bb)