### PR TITLE
Implement v0.1 card battle turn resolution prototype

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>深層防護カードバトル v0.1</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <h1>⚛️ 深層防護カードバトル v0.1</h1>
+      <p class="description">親は毎ターン3枚引いて1枚選択。プレイヤーは防御カードを選んで安全度4000を守り切ります。</p>
+
+      <section class="status-grid">
+        <p>ターン: <strong id="turn">-</strong> / 5</p>
+        <p>安全度: <strong id="safety">-</strong></p>
+      </section>
+
+      <section>
+        <h2>操作</h2>
+        <div class="actions">
+          <button id="init-btn">ゲーム初期化</button>
+          <button id="draw-btn" disabled>親が3枚引く</button>
+          <button id="resolve-btn" disabled>選択攻撃を解決</button>
+        </div>
+      </section>
+
+      <section>
+        <h2>親の候補攻撃（3枚）</h2>
+        <div id="attack-candidates" class="cards"></div>
+      </section>
+
+      <section>
+        <h2>防御カード候補（最大2枚選択）</h2>
+        <div id="defense-options" class="cards"></div>
+      </section>
+
+      <section>
+        <h2>ログ</h2>
+        <pre id="log" class="log">「ゲーム初期化」を押してください。</pre>
+      </section>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,25 +3,36 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>深層防護カードバトル v0.1</title>
+    <title>深層防護カードバトル v0.2</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
     <main class="container">
-      <h1>⚛️ 深層防護カードバトル v0.1</h1>
-      <p class="description">親は毎ターン3枚引いて1枚選択。プレイヤーは防御カードを選んで安全度4000を守り切ります。</p>
+      <h1>⚛️ 深層防護カードバトル v0.2</h1>
+      <p class="description">相談時間後に親が攻撃を確定し、トラップ宣言フェーズ（攻撃確定後〜ダメージ計算前）で防御を宣言します。</p>
 
       <section class="status-grid">
         <p>ターン: <strong id="turn">-</strong> / 5</p>
         <p>安全度: <strong id="safety">-</strong></p>
+        <p>フェーズ: <strong id="phase">-</strong></p>
+        <p>相談タイマー: <strong id="consult-timer">-</strong></p>
+      </section>
+
+      <section>
+        <h2>設定</h2>
+        <div class="settings-row">
+          <label for="consult-seconds">相談時間(秒)</label>
+          <input id="consult-seconds" type="number" min="10" max="180" value="45" />
+        </div>
       </section>
 
       <section>
         <h2>操作</h2>
         <div class="actions">
           <button id="init-btn">ゲーム初期化</button>
-          <button id="draw-btn" disabled>親が3枚引く</button>
-          <button id="resolve-btn" disabled>選択攻撃を解決</button>
+          <button id="draw-btn" disabled>親が3枚引く（相談開始）</button>
+          <button id="trap-phase-btn" disabled>トラップ宣言フェーズへ</button>
+          <button id="resolve-btn" disabled>ダメージ計算を実行</button>
         </div>
       </section>
 
@@ -31,12 +42,12 @@
       </section>
 
       <section>
-        <h2>防御カード候補（最大2枚選択）</h2>
+        <h2>防御カード候補（部署ベース / 最大2枚）</h2>
         <div id="defense-options" class="cards"></div>
       </section>
 
       <section>
-        <h2>ログ</h2>
+        <h2>詳細ログ</h2>
         <pre id="log" class="log">「ゲーム初期化」を押してください。</pre>
       </section>
     </main>

--- a/script.js
+++ b/script.js
@@ -1,84 +1,126 @@
 const ATTACK_CARDS = [
-  { id: "ATK-001", name: "外部電源喪失", tags: ["電源", "拡大"], baseDamage: 700, effects: [{ kind: "disable_system", targetSystemId: "AUTO-002", value: 1 }] },
-  { id: "ATK-002", name: "冷却ポンプ停止", tags: ["冷却", "熱"], baseDamage: 800, effects: [{ kind: "conditional_bonus_damage", condition: "AUTO-002 disabled", value: 200 }] },
-  { id: "ATK-006", name: "手順逸脱", tags: ["人的"], baseDamage: 600, effects: [{ kind: "conditional_bonus_damage", condition: "no_player_response", value: 200 }] },
-  { id: "ATK-011", name: "震度6弱地震", tags: ["地震", "複合"], baseDamage: 900, effects: [{ kind: "disable_system", targetSystemId: "AUTO-003", value: 1 }] },
-  { id: "ATK-016", name: "複合災害シナリオA", tags: ["複合", "地震", "停電"], baseDamage: 1100, effects: [{ kind: "conditional_bonus_damage", condition: "any_auto_system_disabled", value: 200 }] },
-  { id: "ATK-020", name: "最終波状攻撃", tags: ["複合", "最終"], baseDamage: 1300, effects: [{ kind: "playable_only_on_turn", value: 5 }, { kind: "reduce_total_auto_reduction", value: 200 }] },
+  { id: "ATK-001", name: "外部電源喪失", category: "外部ハザード", tags: ["電源", "拡大"], baseDamage: 700, effects: [{ kind: "disable_system", targetSystemId: "AUTO-002", value: 1 }] },
+  { id: "ATK-002", name: "冷却ポンプ停止", category: "内部ハザード", tags: ["冷却", "熱"], baseDamage: 800, effects: [{ kind: "conditional_bonus_damage", condition: "AUTO-002 disabled", value: 200 }] },
+  { id: "ATK-006", name: "手順逸脱", category: "内的事象", tags: ["人的"], baseDamage: 600, effects: [{ kind: "conditional_bonus_damage", condition: "no_player_response", value: 200 }] },
+  { id: "ATK-011", name: "震度6弱地震", category: "外的事象", tags: ["地震", "複合"], baseDamage: 900, effects: [{ kind: "disable_system", targetSystemId: "AUTO-003", value: 1 }] },
+  { id: "ATK-016", name: "複合災害シナリオA", category: "外的事象", tags: ["複合", "地震", "停電"], baseDamage: 1100, effects: [{ kind: "conditional_bonus_damage", condition: "any_auto_system_disabled", value: 200 }] },
+  { id: "ATK-020", name: "最終波状攻撃", category: "外部ハザード", tags: ["複合", "最終"], baseDamage: 1300, effects: [{ kind: "playable_only_on_turn", value: 5 }, { kind: "reduce_total_auto_reduction", value: 200 }] },
 ];
 
 const DEFENSE_CARDS = [
-  { id: "DEF-005", name: "中央監視室アラート", type: "response", tags: ["監視", "制御"], effects: [{ kind: "flat_reduction", value: 250 }] },
-  { id: "DEF-009", name: "非常用ディーゼル運用強化", type: "install", tags: ["拡大防止"], effects: [{ kind: "tag_reduction", targetTagsAny: ["電源"], value: 300 }] },
-  { id: "DEF-010", name: "代替注水ライン切替", type: "emergency", tags: ["拡大防止"], effects: [{ kind: "tag_reduction", targetTagsAny: ["冷却"], value: 350 }] },
-  { id: "DEF-014", name: "区域隔離シャッター", type: "emergency", tags: ["影響緩和"], effects: [{ kind: "flat_reduction", value: 400 }] },
-  { id: "DEF-018", name: "住民避難オペレーション", type: "response", tags: ["防災連携"], effects: [{ kind: "percent_reduction", value: 20 }] },
-  { id: "DEF-019", name: "広域支援要請", type: "emergency", tags: ["防災連携"], effects: [{ kind: "post_resolution_reduction", value: 300 }] },
+  { id: "DEF-005", name: "中央監視室アラート", dept: "運転", deptClass: "dept-ops", type: "response", tags: ["監視", "制御"], effects: [{ kind: "flat_reduction", value: 250 }] },
+  { id: "DEF-009", name: "非常用ディーゼル運用強化", dept: "保全", deptClass: "dept-maint", type: "install", tags: ["拡大防止"], effects: [{ kind: "tag_reduction", targetTagsAny: ["電源"], value: 300 }] },
+  { id: "DEF-010", name: "代替注水ライン切替", dept: "保全", deptClass: "dept-maint", type: "emergency", tags: ["拡大防止"], effects: [{ kind: "tag_reduction", targetTagsAny: ["冷却"], value: 350 }] },
+  { id: "DEF-014", name: "区域隔離シャッター", dept: "安全", deptClass: "dept-safety", type: "emergency", tags: ["影響緩和"], effects: [{ kind: "flat_reduction", value: 400 }] },
+  { id: "DEF-018", name: "住民避難オペレーション", dept: "防災", deptClass: "dept-emergency", type: "response", tags: ["防災連携"], effects: [{ kind: "percent_reduction", value: 20 }] },
+  { id: "DEF-019", name: "広域支援要請", dept: "防災", deptClass: "dept-emergency", type: "emergency", tags: ["防災連携"], effects: [{ kind: "post_resolution_reduction", value: 300 }] },
 ];
+
+const PHASE = {
+  IDLE: "待機",
+  CONSULT: "相談時間",
+  TRAP: "トラップ宣言",
+  ENDED: "終了",
+};
 
 const state = {
   turn: 1,
   maxTurn: 5,
   safety: 4000,
+  phase: PHASE.IDLE,
   selectedAttack: null,
   attackCandidates: [],
   defenseOptions: [],
   autoSystems: {},
+  consultSeconds: 45,
+  consultRemaining: 0,
+  timerId: null,
 };
 
 const el = {
   turn: document.getElementById("turn"),
   safety: document.getElementById("safety"),
+  phase: document.getElementById("phase"),
+  consultTimer: document.getElementById("consult-timer"),
+  consultSeconds: document.getElementById("consult-seconds"),
   attackCandidates: document.getElementById("attack-candidates"),
   defenseOptions: document.getElementById("defense-options"),
   log: document.getElementById("log"),
   initBtn: document.getElementById("init-btn"),
   drawBtn: document.getElementById("draw-btn"),
+  trapPhaseBtn: document.getElementById("trap-phase-btn"),
   resolveBtn: document.getElementById("resolve-btn"),
 };
 
 el.initBtn.addEventListener("click", initGame);
 el.drawBtn.addEventListener("click", drawParentCandidates);
+el.trapPhaseBtn.addEventListener("click", moveToTrapPhase);
 el.resolveBtn.addEventListener("click", resolveCurrentTurn);
 
 function initGame() {
+  clearConsultTimer();
   state.turn = 1;
   state.safety = 4000;
+  state.phase = PHASE.IDLE;
   state.selectedAttack = null;
   state.attackCandidates = [];
   state.defenseOptions = [];
+  state.consultSeconds = clampConsultSeconds(Number(el.consultSeconds.value));
+  el.consultSeconds.value = state.consultSeconds;
+  state.consultRemaining = state.consultSeconds;
   state.autoSystems = {
-    "AUTO-001": { name: "自動スクラム", reduction: 300, health: 2, enabled: true },
+    "AUTO-001": { name: "自動スクラム(トラップ扱い)", reduction: 300, health: 2, enabled: true },
     "AUTO-002": { name: "受動的安全系", reduction: 200, health: 2, enabled: true },
     "AUTO-003": { name: "深層防護基礎", reduction: 100, health: 3, enabled: true },
   };
   el.drawBtn.disabled = false;
+  el.trapPhaseBtn.disabled = true;
   el.resolveBtn.disabled = true;
   render();
-  setLog("ゲームを初期化しました。『親が3枚引く』を押してください。");
+  setLog("初期化完了。『親が3枚引く（相談開始）』を押してください。");
 }
 
 function drawParentCandidates() {
   if (state.turn > state.maxTurn || state.safety <= 0) return;
+  state.phase = PHASE.CONSULT;
   state.selectedAttack = null;
   state.attackCandidates = drawRandomCards(ATTACK_CARDS, 3).filter((c) => {
-    const playRule = c.effects.find((e) => e.kind === "playable_only_on_turn");
-    return !playRule || playRule.value === state.turn;
+    const limit = c.effects.find((e) => e.kind === "playable_only_on_turn");
+    return !limit || limit.value === state.turn;
   });
-  if (state.attackCandidates.length === 0) {
-    state.attackCandidates = drawRandomCards(ATTACK_CARDS.filter((c) => c.id !== "ATK-020"), 3);
+  if (state.attackCandidates.length < 3) {
+    const extra = drawRandomCards(ATTACK_CARDS.filter((c) => c.id !== "ATK-020"), 3 - state.attackCandidates.length);
+    state.attackCandidates.push(...extra);
   }
   state.defenseOptions = drawRandomCards(DEFENSE_CARDS, 4);
+
+  state.consultSeconds = clampConsultSeconds(Number(el.consultSeconds.value));
+  el.consultSeconds.value = state.consultSeconds;
+  state.consultRemaining = state.consultSeconds;
+  startConsultTimer();
+
+  el.drawBtn.disabled = true;
+  el.trapPhaseBtn.disabled = false;
   el.resolveBtn.disabled = true;
   render();
-  setLog("親の攻撃候補を表示しました。攻撃を1枚選び、防御カードを最大2枚チェックして『選択攻撃を解決』を押してください。");
+  setLog("相談時間スタート。攻撃候補を見ながら相談し、攻撃を1枚選択してください。\n相談終了後に『トラップ宣言フェーズへ』を押します。");
+}
+
+function moveToTrapPhase() {
+  if (!state.selectedAttack) {
+    setLog("先に親の攻撃カードを1枚選択してください。");
+    return;
+  }
+  clearConsultTimer();
+  state.phase = PHASE.TRAP;
+  el.trapPhaseBtn.disabled = true;
+  el.resolveBtn.disabled = false;
+  setLog("トラップ宣言フェーズ開始（締切: ダメージ計算前）。\n防御カードを最大2枚チェックし、『ダメージ計算を実行』を押してください。");
+  render();
 }
 
 function resolveCurrentTurn() {
-  if (!state.selectedAttack) {
-    setLog("先に攻撃カードを1枚選択してください。");
-    return;
-  }
+  if (state.phase !== PHASE.TRAP || !state.selectedAttack) return;
 
   const checked = [...el.defenseOptions.querySelectorAll("input[type=checkbox]:checked")];
   if (checked.length > 2) {
@@ -88,29 +130,29 @@ function resolveCurrentTurn() {
 
   const playerActions = checked.map((input) => {
     const card = state.defenseOptions.find((c) => c.id === input.value);
-    return { playerId: input.dataset.playerId, card };
+    return { playerId: input.dataset.dept, card };
   });
 
   const result = resolveAttackTurn(state, state.selectedAttack, playerActions);
 
   const gameEnd = state.safety <= 0 || state.turn >= state.maxTurn;
-  if (!gameEnd) state.turn += 1;
+  if (!gameEnd) {
+    state.turn += 1;
+    state.phase = PHASE.IDLE;
+  } else {
+    state.phase = PHASE.ENDED;
+  }
 
-  render();
-  const outcome = state.safety <= 0 ? "\n\n親の勝利（安全度が0以下）" : state.turn > state.maxTurn ? "\n\nプレイヤー勝利（5ターン耐久）" : "";
+  const outcome = state.safety <= 0 ? "\n\n親の勝利（安全度0）" : gameEnd ? "\n\nプレイヤー勝利（5ターン耐久）" : "";
   setLog(formatLog(result.log) + outcome);
 
   state.selectedAttack = null;
   state.attackCandidates = [];
   state.defenseOptions = [];
 
-  if (gameEnd) {
-    el.drawBtn.disabled = true;
-    el.resolveBtn.disabled = true;
-  } else {
-    el.drawBtn.disabled = false;
-    el.resolveBtn.disabled = true;
-  }
+  el.drawBtn.disabled = gameEnd;
+  el.trapPhaseBtn.disabled = true;
+  el.resolveBtn.disabled = true;
   render();
 }
 
@@ -118,83 +160,76 @@ function resolveAttackTurn(stateObj, selectedAttack, playerActions) {
   const turnCtx = createTurnContext(stateObj, selectedAttack, playerActions);
   validatePlayerActionLimits(turnCtx);
 
-  const baseDamage = getBaseDamage(selectedAttack);
-  const autoReductionDetail = applyAutoSafetyBoardReductions(turnCtx, selectedAttack);
-  const defenseReductionDetail = applyDefenseCardReductions(turnCtx, selectedAttack);
-  const attackBonusDetail = applyAttackCardEffects(turnCtx, selectedAttack);
-  const layerBonus = calcLayerSynergyBonus(turnCtx);
+  const baseDamage = selectedAttack.baseDamage;
+  const autoReduction = applyAutoSafetyBoardReductions(turnCtx, selectedAttack);
+  const defenseReduction = applyDefenseCardReductions(turnCtx, selectedAttack);
+  const attackBonus = applyAttackCardEffects(turnCtx, selectedAttack);
 
-  let provisionalDamage =
-    baseDamage +
-    attackBonusDetail.totalBonus -
-    autoReductionDetail.totalReduction -
-    defenseReductionDetail.totalReduction -
-    layerBonus;
+  let damage = Math.max(0, baseDamage + attackBonus.totalBonus - autoReduction.totalReduction - defenseReduction.totalReduction);
+  damage = applyPostResolutionReductions(turnCtx, damage);
 
-  provisionalDamage = Math.max(0, provisionalDamage);
-  const finalDamage = applyPostResolutionReductions(turnCtx, provisionalDamage);
-
-  stateObj.safety = Math.max(0, stateObj.safety - finalDamage);
+  stateObj.safety = Math.max(0, stateObj.safety - damage);
   applyStateMutations(turnCtx);
 
   return {
-    finalDamage,
-    log: buildResolutionLog(selectedAttack, baseDamage, autoReductionDetail, defenseReductionDetail, layerBonus, attackBonusDetail, finalDamage, stateObj.safety),
+    finalDamage: damage,
+    log: buildResolutionLog(selectedAttack, baseDamage, autoReduction, defenseReduction, attackBonus, damage, stateObj.safety, playerActions),
   };
 }
 
 function createTurnContext(stateObj, selectedAttack, playerActions) {
   return {
-    turn: stateObj.turn,
+    state: stateObj,
     selectedAttack,
     playerActions,
-    state: stateObj,
-    usedTags: new Set(playerActions.flatMap((a) => a.card.tags || [])),
     postResolutionReduction: 0,
+    percentReduction: 0,
   };
 }
 
 function validatePlayerActionLimits(turnCtx) {
-  const perPlayer = new Map();
+  const countByDept = new Map();
   for (const action of turnCtx.playerActions) {
-    if (!perPlayer.has(action.playerId)) perPlayer.set(action.playerId, { install: 0, response: 0, emergency: 0 });
-    perPlayer.get(action.playerId)[action.card.type] += 1;
+    if (!countByDept.has(action.playerId)) countByDept.set(action.playerId, { install: 0, response: 0, emergency: 0 });
+    countByDept.get(action.playerId)[action.card.type] += 1;
   }
-  for (const counters of perPlayer.values()) {
+  for (const counters of countByDept.values()) {
     if (counters.install > 1 || counters.response > 1 || counters.emergency > 1) {
-      throw new Error("同一プレイヤーの行動上限を超えています。");
+      throw new Error("同一部署の行動上限を超えています。");
     }
   }
-}
-
-function getBaseDamage(attack) {
-  return attack.baseDamage;
 }
 
 function applyAutoSafetyBoardReductions(turnCtx, attack) {
   const items = [];
   let totalReduction = 0;
-  const systems = turnCtx.state.autoSystems;
 
-  if (systems["AUTO-003"].enabled) {
-    totalReduction += systems["AUTO-003"].reduction;
-    items.push({ source: systems["AUTO-003"].name, value: systems["AUTO-003"].reduction });
+  const s = turnCtx.state.autoSystems;
+  if (s["AUTO-003"].enabled) {
+    totalReduction += s["AUTO-003"].reduction;
+    items.push({ source: s["AUTO-003"].name, value: s["AUTO-003"].reduction });
   }
 
-  if (systems["AUTO-001"].enabled && attack.tags.some((t) => ["地震", "複合"].includes(t))) {
-    totalReduction += systems["AUTO-001"].reduction;
-    items.push({ source: systems["AUTO-001"].name, value: systems["AUTO-001"].reduction });
+  // 自動スクラムはトラップカード的運用: 攻撃が外的事象/外部ハザードの場合に宣言されていれば適用
+  const scramDeclared = turnCtx.playerActions.some((a) => a.card.id === "DEF-005");
+  if (s["AUTO-001"].enabled && scramDeclared && ["外的事象", "外部ハザード"].includes(attack.category)) {
+    if (Math.random() >= 0.05) {
+      totalReduction += s["AUTO-001"].reduction;
+      items.push({ source: `${s["AUTO-001"].name}(成功)`, value: s["AUTO-001"].reduction });
+    } else {
+      items.push({ source: `${s["AUTO-001"].name}(失敗)`, value: 0 });
+    }
   }
 
-  if (systems["AUTO-002"].enabled && attack.tags.some((t) => ["冷却", "熱"].includes(t))) {
-    totalReduction += systems["AUTO-002"].reduction;
-    items.push({ source: systems["AUTO-002"].name, value: systems["AUTO-002"].reduction });
+  if (s["AUTO-002"].enabled && attack.tags.some((t) => ["冷却", "熱"].includes(t))) {
+    totalReduction += s["AUTO-002"].reduction;
+    items.push({ source: s["AUTO-002"].name, value: s["AUTO-002"].reduction });
   }
 
   const reduceAuto = attack.effects.find((e) => e.kind === "reduce_total_auto_reduction");
   if (reduceAuto) {
     totalReduction = Math.max(0, totalReduction - reduceAuto.value);
-    items.push({ source: "攻撃効果(自動軽減低下)", value: -reduceAuto.value });
+    items.push({ source: "攻撃効果:自動軽減低下", value: -reduceAuto.value });
   }
 
   return { totalReduction, items };
@@ -208,15 +243,15 @@ function applyDefenseCardReductions(turnCtx, attack) {
     for (const effect of action.card.effects) {
       if (effect.kind === "flat_reduction") {
         totalReduction += effect.value;
-        items.push({ source: action.card.name, value: effect.value });
+        items.push({ source: `${action.playerId}/${action.card.name}`, value: effect.value });
       }
       if (effect.kind === "tag_reduction" && attack.tags.some((t) => effect.targetTagsAny.includes(t))) {
         totalReduction += effect.value;
-        items.push({ source: action.card.name, value: effect.value });
+        items.push({ source: `${action.playerId}/${action.card.name}`, value: effect.value });
       }
       if (effect.kind === "percent_reduction") {
-        turnCtx.percentReduction = Math.max(turnCtx.percentReduction || 0, effect.value);
-        items.push({ source: `${action.card.name}(割合軽減)`, value: `${effect.value}%` });
+        turnCtx.percentReduction = Math.max(turnCtx.percentReduction, effect.value);
+        items.push({ source: `${action.playerId}/${action.card.name}(割合)`, value: `${effect.value}%` });
       }
       if (effect.kind === "post_resolution_reduction") {
         turnCtx.postResolutionReduction += effect.value;
@@ -229,37 +264,19 @@ function applyDefenseCardReductions(turnCtx, attack) {
 
 function applyAttackCardEffects(turnCtx, attack) {
   let totalBonus = 0;
-
   for (const effect of attack.effects) {
     if (effect.kind === "conditional_bonus_damage") {
-      if (effect.condition === "AUTO-002 disabled" && !turnCtx.state.autoSystems["AUTO-002"].enabled) {
-        totalBonus += effect.value;
-      }
-      if (effect.condition === "no_player_response" && !turnCtx.playerActions.some((a) => a.card.type === "response")) {
-        totalBonus += effect.value;
-      }
-      if (effect.condition === "any_auto_system_disabled" && Object.values(turnCtx.state.autoSystems).some((s) => !s.enabled)) {
-        totalBonus += effect.value;
-      }
+      if (effect.condition === "AUTO-002 disabled" && !turnCtx.state.autoSystems["AUTO-002"].enabled) totalBonus += effect.value;
+      if (effect.condition === "no_player_response" && !turnCtx.playerActions.some((a) => a.card.type === "response")) totalBonus += effect.value;
+      if (effect.condition === "any_auto_system_disabled" && Object.values(turnCtx.state.autoSystems).some((sys) => !sys.enabled)) totalBonus += effect.value;
     }
   }
-
   return { totalBonus };
-}
-
-function calcLayerSynergyBonus(turnCtx) {
-  const layers = new Set();
-  for (const tag of turnCtx.usedTags) {
-    if (["予防", "監視", "制御", "拡大防止", "影響緩和", "防災連携"].includes(tag)) layers.add(tag);
-  }
-  return layers.size >= 3 ? 200 : layers.size >= 2 ? 100 : 0;
 }
 
 function applyPostResolutionReductions(turnCtx, damage) {
   let out = Math.max(0, damage - turnCtx.postResolutionReduction);
-  if (turnCtx.percentReduction) {
-    out = Math.max(0, Math.floor(out * (100 - turnCtx.percentReduction) / 100));
-  }
+  if (turnCtx.percentReduction) out = Math.max(0, Math.floor(out * (100 - turnCtx.percentReduction) / 100));
   return out;
 }
 
@@ -273,17 +290,42 @@ function applyStateMutations(turnCtx) {
   }
 }
 
-function buildResolutionLog(attack, baseDamage, autoReduction, defenseReduction, layerBonus, attackBonus, finalDamage, safetyAfter) {
+function buildResolutionLog(attack, baseDamage, autoReduction, defenseReduction, attackBonus, finalDamage, safetyAfter, actions) {
   return {
     attack: `${attack.id} ${attack.name}`,
+    attackCategory: attack.category,
+    attackTags: attack.tags,
+    declarations: actions.map((a) => `${a.playerId}:${a.card.name}`),
     baseDamage,
     autoReduction,
     defenseReduction,
-    layerBonus,
     attackBonus,
     finalDamage,
     safetyAfter,
   };
+}
+
+function startConsultTimer() {
+  clearConsultTimer();
+  state.consultRemaining = state.consultSeconds;
+  state.timerId = setInterval(() => {
+    state.consultRemaining -= 1;
+    if (state.consultRemaining <= 0) {
+      clearConsultTimer();
+      state.consultRemaining = 0;
+      if (state.phase === PHASE.CONSULT) {
+        setLog("相談時間が終了しました。攻撃を選択して『トラップ宣言フェーズへ』を押してください。");
+      }
+    }
+    render();
+  }, 1000);
+}
+
+function clearConsultTimer() {
+  if (state.timerId) {
+    clearInterval(state.timerId);
+    state.timerId = null;
+  }
 }
 
 function drawRandomCards(pool, count) {
@@ -299,9 +341,16 @@ function shuffle(arr) {
   }
 }
 
+function clampConsultSeconds(v) {
+  if (Number.isNaN(v)) return 45;
+  return Math.min(180, Math.max(10, Math.floor(v)));
+}
+
 function render() {
   el.turn.textContent = state.turn;
   el.safety.textContent = state.safety;
+  el.phase.textContent = state.phase;
+  el.consultTimer.textContent = `${state.consultRemaining}s`;
   renderAttacks();
   renderDefenses();
 }
@@ -311,10 +360,10 @@ function renderAttacks() {
   state.attackCandidates.forEach((card) => {
     const btn = document.createElement("button");
     btn.className = `card attack ${state.selectedAttack?.id === card.id ? "selected" : ""}`;
-    btn.innerHTML = `<strong>${card.name}</strong><small>${card.id} / ダメージ ${card.baseDamage}</small><small>タグ: ${card.tags.join("・")}</small>`;
+    btn.innerHTML = `<strong>${card.name}</strong><small>${card.id} / ${card.category}</small><small>ダメージ ${card.baseDamage} / タグ ${card.tags.join("・")}</small>`;
+    btn.disabled = state.phase === PHASE.TRAP;
     btn.addEventListener("click", () => {
       state.selectedAttack = card;
-      el.resolveBtn.disabled = false;
       renderAttacks();
     });
     el.attackCandidates.appendChild(btn);
@@ -323,15 +372,14 @@ function renderAttacks() {
 
 function renderDefenses() {
   el.defenseOptions.innerHTML = "";
-  const playerIds = ["A", "B", "C", "D"];
-  state.defenseOptions.forEach((card, idx) => {
+  state.defenseOptions.forEach((card) => {
     const box = document.createElement("label");
-    box.className = "card defense";
-    const playerId = playerIds[idx % playerIds.length];
+    box.className = `card defense ${card.deptClass}`;
+    const lock = state.phase !== PHASE.TRAP ? "disabled" : "";
     box.innerHTML = `
-      <input type="checkbox" value="${card.id}" data-player-id="${playerId}" />
+      <input type="checkbox" value="${card.id}" data-dept="${card.dept}" ${lock} />
       <strong>${card.name}</strong>
-      <small>${card.id} / 種別: ${card.type}</small>
+      <small>${card.id} / 部署: ${card.dept} / 種別: ${card.type}</small>
       <small>タグ: ${card.tags.join("・")}</small>
     `;
     el.defenseOptions.appendChild(box);
@@ -341,10 +389,12 @@ function renderDefenses() {
 function formatLog(log) {
   return [
     `攻撃: ${log.attack}`,
+    `カテゴリ: ${log.attackCategory}`,
+    `タグ: ${log.attackTags.join("・")}`,
+    `宣言: ${log.declarations.join(" | ") || "なし"}`,
     `基本ダメージ: ${log.baseDamage}`,
-    `自動軽減: ${log.autoReduction.items.map((i) => `${i.source}:${i.value}`).join(", ") || "なし"}`,
-    `防御軽減: ${log.defenseReduction.items.map((i) => `${i.source}:${i.value}`).join(", ") || "なし"}`,
-    `層ボーナス: ${log.layerBonus}`,
+    `自動軽減: ${log.autoReduction.items.map((x) => `${x.source}:${x.value}`).join(" / ") || "なし"}`,
+    `防御軽減: ${log.defenseReduction.items.map((x) => `${x.source}:${x.value}`).join(" / ") || "なし"}`,
     `攻撃ボーナス: ${log.attackBonus.totalBonus}`,
     `最終ダメージ: ${log.finalDamage}`,
     `解決後安全度: ${log.safetyAfter}`,

--- a/script.js
+++ b/script.js
@@ -1,0 +1,356 @@
+const ATTACK_CARDS = [
+  { id: "ATK-001", name: "外部電源喪失", tags: ["電源", "拡大"], baseDamage: 700, effects: [{ kind: "disable_system", targetSystemId: "AUTO-002", value: 1 }] },
+  { id: "ATK-002", name: "冷却ポンプ停止", tags: ["冷却", "熱"], baseDamage: 800, effects: [{ kind: "conditional_bonus_damage", condition: "AUTO-002 disabled", value: 200 }] },
+  { id: "ATK-006", name: "手順逸脱", tags: ["人的"], baseDamage: 600, effects: [{ kind: "conditional_bonus_damage", condition: "no_player_response", value: 200 }] },
+  { id: "ATK-011", name: "震度6弱地震", tags: ["地震", "複合"], baseDamage: 900, effects: [{ kind: "disable_system", targetSystemId: "AUTO-003", value: 1 }] },
+  { id: "ATK-016", name: "複合災害シナリオA", tags: ["複合", "地震", "停電"], baseDamage: 1100, effects: [{ kind: "conditional_bonus_damage", condition: "any_auto_system_disabled", value: 200 }] },
+  { id: "ATK-020", name: "最終波状攻撃", tags: ["複合", "最終"], baseDamage: 1300, effects: [{ kind: "playable_only_on_turn", value: 5 }, { kind: "reduce_total_auto_reduction", value: 200 }] },
+];
+
+const DEFENSE_CARDS = [
+  { id: "DEF-005", name: "中央監視室アラート", type: "response", tags: ["監視", "制御"], effects: [{ kind: "flat_reduction", value: 250 }] },
+  { id: "DEF-009", name: "非常用ディーゼル運用強化", type: "install", tags: ["拡大防止"], effects: [{ kind: "tag_reduction", targetTagsAny: ["電源"], value: 300 }] },
+  { id: "DEF-010", name: "代替注水ライン切替", type: "emergency", tags: ["拡大防止"], effects: [{ kind: "tag_reduction", targetTagsAny: ["冷却"], value: 350 }] },
+  { id: "DEF-014", name: "区域隔離シャッター", type: "emergency", tags: ["影響緩和"], effects: [{ kind: "flat_reduction", value: 400 }] },
+  { id: "DEF-018", name: "住民避難オペレーション", type: "response", tags: ["防災連携"], effects: [{ kind: "percent_reduction", value: 20 }] },
+  { id: "DEF-019", name: "広域支援要請", type: "emergency", tags: ["防災連携"], effects: [{ kind: "post_resolution_reduction", value: 300 }] },
+];
+
+const state = {
+  turn: 1,
+  maxTurn: 5,
+  safety: 4000,
+  selectedAttack: null,
+  attackCandidates: [],
+  defenseOptions: [],
+  autoSystems: {},
+};
+
+const el = {
+  turn: document.getElementById("turn"),
+  safety: document.getElementById("safety"),
+  attackCandidates: document.getElementById("attack-candidates"),
+  defenseOptions: document.getElementById("defense-options"),
+  log: document.getElementById("log"),
+  initBtn: document.getElementById("init-btn"),
+  drawBtn: document.getElementById("draw-btn"),
+  resolveBtn: document.getElementById("resolve-btn"),
+};
+
+el.initBtn.addEventListener("click", initGame);
+el.drawBtn.addEventListener("click", drawParentCandidates);
+el.resolveBtn.addEventListener("click", resolveCurrentTurn);
+
+function initGame() {
+  state.turn = 1;
+  state.safety = 4000;
+  state.selectedAttack = null;
+  state.attackCandidates = [];
+  state.defenseOptions = [];
+  state.autoSystems = {
+    "AUTO-001": { name: "自動スクラム", reduction: 300, health: 2, enabled: true },
+    "AUTO-002": { name: "受動的安全系", reduction: 200, health: 2, enabled: true },
+    "AUTO-003": { name: "深層防護基礎", reduction: 100, health: 3, enabled: true },
+  };
+  el.drawBtn.disabled = false;
+  el.resolveBtn.disabled = true;
+  render();
+  setLog("ゲームを初期化しました。『親が3枚引く』を押してください。");
+}
+
+function drawParentCandidates() {
+  if (state.turn > state.maxTurn || state.safety <= 0) return;
+  state.selectedAttack = null;
+  state.attackCandidates = drawRandomCards(ATTACK_CARDS, 3).filter((c) => {
+    const playRule = c.effects.find((e) => e.kind === "playable_only_on_turn");
+    return !playRule || playRule.value === state.turn;
+  });
+  if (state.attackCandidates.length === 0) {
+    state.attackCandidates = drawRandomCards(ATTACK_CARDS.filter((c) => c.id !== "ATK-020"), 3);
+  }
+  state.defenseOptions = drawRandomCards(DEFENSE_CARDS, 4);
+  el.resolveBtn.disabled = true;
+  render();
+  setLog("親の攻撃候補を表示しました。攻撃を1枚選び、防御カードを最大2枚チェックして『選択攻撃を解決』を押してください。");
+}
+
+function resolveCurrentTurn() {
+  if (!state.selectedAttack) {
+    setLog("先に攻撃カードを1枚選択してください。");
+    return;
+  }
+
+  const checked = [...el.defenseOptions.querySelectorAll("input[type=checkbox]:checked")];
+  if (checked.length > 2) {
+    setLog("防御カードは最大2枚までです。");
+    return;
+  }
+
+  const playerActions = checked.map((input) => {
+    const card = state.defenseOptions.find((c) => c.id === input.value);
+    return { playerId: input.dataset.playerId, card };
+  });
+
+  const result = resolveAttackTurn(state, state.selectedAttack, playerActions);
+
+  const gameEnd = state.safety <= 0 || state.turn >= state.maxTurn;
+  if (!gameEnd) state.turn += 1;
+
+  render();
+  const outcome = state.safety <= 0 ? "\n\n親の勝利（安全度が0以下）" : state.turn > state.maxTurn ? "\n\nプレイヤー勝利（5ターン耐久）" : "";
+  setLog(formatLog(result.log) + outcome);
+
+  state.selectedAttack = null;
+  state.attackCandidates = [];
+  state.defenseOptions = [];
+
+  if (gameEnd) {
+    el.drawBtn.disabled = true;
+    el.resolveBtn.disabled = true;
+  } else {
+    el.drawBtn.disabled = false;
+    el.resolveBtn.disabled = true;
+  }
+  render();
+}
+
+function resolveAttackTurn(stateObj, selectedAttack, playerActions) {
+  const turnCtx = createTurnContext(stateObj, selectedAttack, playerActions);
+  validatePlayerActionLimits(turnCtx);
+
+  const baseDamage = getBaseDamage(selectedAttack);
+  const autoReductionDetail = applyAutoSafetyBoardReductions(turnCtx, selectedAttack);
+  const defenseReductionDetail = applyDefenseCardReductions(turnCtx, selectedAttack);
+  const attackBonusDetail = applyAttackCardEffects(turnCtx, selectedAttack);
+  const layerBonus = calcLayerSynergyBonus(turnCtx);
+
+  let provisionalDamage =
+    baseDamage +
+    attackBonusDetail.totalBonus -
+    autoReductionDetail.totalReduction -
+    defenseReductionDetail.totalReduction -
+    layerBonus;
+
+  provisionalDamage = Math.max(0, provisionalDamage);
+  const finalDamage = applyPostResolutionReductions(turnCtx, provisionalDamage);
+
+  stateObj.safety = Math.max(0, stateObj.safety - finalDamage);
+  applyStateMutations(turnCtx);
+
+  return {
+    finalDamage,
+    log: buildResolutionLog(selectedAttack, baseDamage, autoReductionDetail, defenseReductionDetail, layerBonus, attackBonusDetail, finalDamage, stateObj.safety),
+  };
+}
+
+function createTurnContext(stateObj, selectedAttack, playerActions) {
+  return {
+    turn: stateObj.turn,
+    selectedAttack,
+    playerActions,
+    state: stateObj,
+    usedTags: new Set(playerActions.flatMap((a) => a.card.tags || [])),
+    postResolutionReduction: 0,
+  };
+}
+
+function validatePlayerActionLimits(turnCtx) {
+  const perPlayer = new Map();
+  for (const action of turnCtx.playerActions) {
+    if (!perPlayer.has(action.playerId)) perPlayer.set(action.playerId, { install: 0, response: 0, emergency: 0 });
+    perPlayer.get(action.playerId)[action.card.type] += 1;
+  }
+  for (const counters of perPlayer.values()) {
+    if (counters.install > 1 || counters.response > 1 || counters.emergency > 1) {
+      throw new Error("同一プレイヤーの行動上限を超えています。");
+    }
+  }
+}
+
+function getBaseDamage(attack) {
+  return attack.baseDamage;
+}
+
+function applyAutoSafetyBoardReductions(turnCtx, attack) {
+  const items = [];
+  let totalReduction = 0;
+  const systems = turnCtx.state.autoSystems;
+
+  if (systems["AUTO-003"].enabled) {
+    totalReduction += systems["AUTO-003"].reduction;
+    items.push({ source: systems["AUTO-003"].name, value: systems["AUTO-003"].reduction });
+  }
+
+  if (systems["AUTO-001"].enabled && attack.tags.some((t) => ["地震", "複合"].includes(t))) {
+    totalReduction += systems["AUTO-001"].reduction;
+    items.push({ source: systems["AUTO-001"].name, value: systems["AUTO-001"].reduction });
+  }
+
+  if (systems["AUTO-002"].enabled && attack.tags.some((t) => ["冷却", "熱"].includes(t))) {
+    totalReduction += systems["AUTO-002"].reduction;
+    items.push({ source: systems["AUTO-002"].name, value: systems["AUTO-002"].reduction });
+  }
+
+  const reduceAuto = attack.effects.find((e) => e.kind === "reduce_total_auto_reduction");
+  if (reduceAuto) {
+    totalReduction = Math.max(0, totalReduction - reduceAuto.value);
+    items.push({ source: "攻撃効果(自動軽減低下)", value: -reduceAuto.value });
+  }
+
+  return { totalReduction, items };
+}
+
+function applyDefenseCardReductions(turnCtx, attack) {
+  let totalReduction = 0;
+  const items = [];
+
+  for (const action of turnCtx.playerActions) {
+    for (const effect of action.card.effects) {
+      if (effect.kind === "flat_reduction") {
+        totalReduction += effect.value;
+        items.push({ source: action.card.name, value: effect.value });
+      }
+      if (effect.kind === "tag_reduction" && attack.tags.some((t) => effect.targetTagsAny.includes(t))) {
+        totalReduction += effect.value;
+        items.push({ source: action.card.name, value: effect.value });
+      }
+      if (effect.kind === "percent_reduction") {
+        turnCtx.percentReduction = Math.max(turnCtx.percentReduction || 0, effect.value);
+        items.push({ source: `${action.card.name}(割合軽減)`, value: `${effect.value}%` });
+      }
+      if (effect.kind === "post_resolution_reduction") {
+        turnCtx.postResolutionReduction += effect.value;
+      }
+    }
+  }
+
+  return { totalReduction, items };
+}
+
+function applyAttackCardEffects(turnCtx, attack) {
+  let totalBonus = 0;
+
+  for (const effect of attack.effects) {
+    if (effect.kind === "conditional_bonus_damage") {
+      if (effect.condition === "AUTO-002 disabled" && !turnCtx.state.autoSystems["AUTO-002"].enabled) {
+        totalBonus += effect.value;
+      }
+      if (effect.condition === "no_player_response" && !turnCtx.playerActions.some((a) => a.card.type === "response")) {
+        totalBonus += effect.value;
+      }
+      if (effect.condition === "any_auto_system_disabled" && Object.values(turnCtx.state.autoSystems).some((s) => !s.enabled)) {
+        totalBonus += effect.value;
+      }
+    }
+  }
+
+  return { totalBonus };
+}
+
+function calcLayerSynergyBonus(turnCtx) {
+  const layers = new Set();
+  for (const tag of turnCtx.usedTags) {
+    if (["予防", "監視", "制御", "拡大防止", "影響緩和", "防災連携"].includes(tag)) layers.add(tag);
+  }
+  return layers.size >= 3 ? 200 : layers.size >= 2 ? 100 : 0;
+}
+
+function applyPostResolutionReductions(turnCtx, damage) {
+  let out = Math.max(0, damage - turnCtx.postResolutionReduction);
+  if (turnCtx.percentReduction) {
+    out = Math.max(0, Math.floor(out * (100 - turnCtx.percentReduction) / 100));
+  }
+  return out;
+}
+
+function applyStateMutations(turnCtx) {
+  for (const effect of turnCtx.selectedAttack.effects) {
+    if (effect.kind === "disable_system") {
+      const system = turnCtx.state.autoSystems[effect.targetSystemId];
+      system.health = Math.max(0, system.health - effect.value);
+      system.enabled = system.health > 0;
+    }
+  }
+}
+
+function buildResolutionLog(attack, baseDamage, autoReduction, defenseReduction, layerBonus, attackBonus, finalDamage, safetyAfter) {
+  return {
+    attack: `${attack.id} ${attack.name}`,
+    baseDamage,
+    autoReduction,
+    defenseReduction,
+    layerBonus,
+    attackBonus,
+    finalDamage,
+    safetyAfter,
+  };
+}
+
+function drawRandomCards(pool, count) {
+  const copy = [...pool];
+  shuffle(copy);
+  return copy.slice(0, count);
+}
+
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+
+function render() {
+  el.turn.textContent = state.turn;
+  el.safety.textContent = state.safety;
+  renderAttacks();
+  renderDefenses();
+}
+
+function renderAttacks() {
+  el.attackCandidates.innerHTML = "";
+  state.attackCandidates.forEach((card) => {
+    const btn = document.createElement("button");
+    btn.className = `card attack ${state.selectedAttack?.id === card.id ? "selected" : ""}`;
+    btn.innerHTML = `<strong>${card.name}</strong><small>${card.id} / ダメージ ${card.baseDamage}</small><small>タグ: ${card.tags.join("・")}</small>`;
+    btn.addEventListener("click", () => {
+      state.selectedAttack = card;
+      el.resolveBtn.disabled = false;
+      renderAttacks();
+    });
+    el.attackCandidates.appendChild(btn);
+  });
+}
+
+function renderDefenses() {
+  el.defenseOptions.innerHTML = "";
+  const playerIds = ["A", "B", "C", "D"];
+  state.defenseOptions.forEach((card, idx) => {
+    const box = document.createElement("label");
+    box.className = "card defense";
+    const playerId = playerIds[idx % playerIds.length];
+    box.innerHTML = `
+      <input type="checkbox" value="${card.id}" data-player-id="${playerId}" />
+      <strong>${card.name}</strong>
+      <small>${card.id} / 種別: ${card.type}</small>
+      <small>タグ: ${card.tags.join("・")}</small>
+    `;
+    el.defenseOptions.appendChild(box);
+  });
+}
+
+function formatLog(log) {
+  return [
+    `攻撃: ${log.attack}`,
+    `基本ダメージ: ${log.baseDamage}`,
+    `自動軽減: ${log.autoReduction.items.map((i) => `${i.source}:${i.value}`).join(", ") || "なし"}`,
+    `防御軽減: ${log.defenseReduction.items.map((i) => `${i.source}:${i.value}`).join(", ") || "なし"}`,
+    `層ボーナス: ${log.layerBonus}`,
+    `攻撃ボーナス: ${log.attackBonus.totalBonus}`,
+    `最終ダメージ: ${log.finalDamage}`,
+    `解決後安全度: ${log.safetyAfter}`,
+  ].join("\n");
+}
+
+function setLog(text) {
+  el.log.textContent = text;
+}

--- a/styles.css
+++ b/styles.css
@@ -13,8 +13,8 @@ body {
 }
 
 .container {
-  width: min(980px, 94vw);
-  background: rgba(0, 0, 0, 0.3);
+  width: min(1100px, 96vw);
+  background: rgba(0, 0, 0, 0.32);
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 12px;
   padding: 1.1rem;
@@ -31,8 +31,21 @@ h2 {
 
 .status-grid {
   display: grid;
-  grid-template-columns: repeat(2, minmax(120px, 1fr));
+  grid-template-columns: repeat(4, minmax(130px, 1fr));
   gap: 0.8rem;
+}
+
+.settings-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+input[type="number"] {
+  width: 86px;
+  border-radius: 6px;
+  border: 1px solid #b9c3ec;
+  padding: 0.3rem;
 }
 
 .actions {
@@ -58,7 +71,7 @@ button:disabled {
 
 .cards {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
   gap: 0.6rem;
 }
 
@@ -83,9 +96,25 @@ button:disabled {
   border-left: 6px solid #42a35a;
 }
 
+.dept-ops {
+  background: #e8f0ff;
+}
+
+.dept-maint {
+  background: #edfbe7;
+}
+
+.dept-safety {
+  background: #fff4de;
+}
+
+.dept-emergency {
+  background: #ffe9ec;
+}
+
 .card small {
   display: block;
-  opacity: 0.8;
+  opacity: 0.84;
 }
 
 .log {
@@ -94,6 +123,6 @@ button:disabled {
   border: 1px solid #313a5c;
   border-radius: 8px;
   padding: 0.8rem;
-  min-height: 130px;
+  min-height: 180px;
   white-space: pre-wrap;
 }

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,99 @@
+:root {
+  color-scheme: light;
+  font-family: "Segoe UI", "Hiragino Kaku Gothic ProN", Meiryo, sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at top, #213a8f, #1a1a2f);
+  color: #f8f8ff;
+}
+
+.container {
+  width: min(980px, 94vw);
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 12px;
+  padding: 1.1rem;
+}
+
+h1,
+h2 {
+  margin: 0.5rem 0;
+}
+
+.description {
+  opacity: 0.92;
+}
+
+.status-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(120px, 1fr));
+  gap: 0.8rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+button {
+  border: none;
+  border-radius: 8px;
+  padding: 0.65rem 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  background: #ffd34f;
+  color: #2d2100;
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.6rem;
+}
+
+.card {
+  background: #f8f8ff;
+  color: #191a1f;
+  border-radius: 8px;
+  border: 1px solid #d9d9ef;
+  padding: 0.55rem;
+  font-size: 0.92rem;
+}
+
+.card.selected {
+  outline: 3px solid #38c2ff;
+}
+
+.card.attack {
+  border-left: 6px solid #c9404d;
+}
+
+.card.defense {
+  border-left: 6px solid #42a35a;
+}
+
+.card small {
+  display: block;
+  opacity: 0.8;
+}
+
+.log {
+  margin: 0;
+  background: #0f1220;
+  border: 1px solid #313a5c;
+  border-radius: 8px;
+  padding: 0.8rem;
+  min-height: 130px;
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
## Summary
- replace the poker UI with a v0.1 deep-defense card battle prototype
- implement parent-side 3-card draw and 1-card attack selection flow
- add defense option selection and turn resolution logging

## Implementation details
- rewrote `script.js` with a decomposed `resolveAttackTurn(state, selectedAttack, playerActions)` pipeline and helper functions:
  - `createTurnContext`
  - `validatePlayerActionLimits`
  - `applyAutoSafetyBoardReductions`
  - `applyDefenseCardReductions`
  - `applyAttackCardEffects`
  - `calcLayerSynergyBonus`
  - `applyPostResolutionReductions`
  - `applyStateMutations`
  - `buildResolutionLog`
- introduced initial attack/defense card datasets and auto safety board state
- updated `index.html` to support initialization, parent draw, attack selection, defense selection, and log output
- refreshed `styles.css` for the new card battle layout and controls

## Validation
- served the app locally with Python `http.server`
- exercised one full turn via browser automation (init -> draw -> select attack -> select defense -> resolve)
- captured screenshot artifact of the working UI

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d5185cae88326adb9e00a4ea8f8bb)